### PR TITLE
GH-1: Need to test Github integration

### DIFF
--- a/.agent22.example.yml
+++ b/.agent22.example.yml
@@ -1,26 +1,33 @@
-***REMOVED***
-***REMOVED***
+work_provider: "jira" # supported: jira, github
+scm_provider: "gitea" # supported: gitea, gitlab, github
+coding_agent_provider: "opencode" # supported: opencode, cursor
+wait_time_seconds: 30
 
-***REMOVED***
+# Optional when coding_agent_provider is "cursor"
+# cursor_cli_command: "cursor-agent"
+
+jira:
   email: "you@example.com"
   api_token: ""
   jql: "project = EXAMPLE AND status = 'ready'"
   base_url: "https://your-org.atlassian.net"
-***REMOVED***
-***REMOVED***
-***REMOVED***
+  max_results: 25
+  pr_status: "PR Ready"
+  done_status: "Done"
 
-***REMOVED***
-***REMOVED***
-***REMOVED***
+github_work:
+  labels: ["ready"]
+  in_progress_label: "in-progress"
+  done_label: "done"
+
+git_repo: "your-repo"
+git_base_branch: "main"
+git_remote: "origin"
 
 gitea_owner: "your-gitea-owner"
 gitea_token: ""
 gitea_base_url: "https://gitea.example.com"
 
-scm_provider: "gitea"
-coding_agent_provider: "opencode"
-# cursor_cli_command: "cursor-agent" # also supports args, e.g. "bunx cursor-agent --profile ci"
 gitlab_token: ""
 gitlab_base_url: "https://gitlab.example.com"
 gitlab_project_path: "group/subgroup/project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,22 @@ RUN apt-get update \
         openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://opencode.ai/install | bash
+ARG OPENCODE_VERSION=1.2.10
+ARG OPENCODE_SHA256_AMD64=ebcc24012e8f067b10d7416430c88e9c429115ecfbccf8da9eb59db3b629a358
+ARG OPENCODE_SHA256_ARM64=d9a9d4f0bc1ed246258c0e8846e80593755a72bf4afd3940c4071d6f0b7b7775
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) opencode_arch="x64"; opencode_sha256="${OPENCODE_SHA256_AMD64}" ;; \
+        arm64) opencode_arch="arm64"; opencode_sha256="${OPENCODE_SHA256_ARM64}" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    opencode_url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${opencode_arch}.tar.gz"; \
+    curl -fsSL "${opencode_url}" -o /tmp/opencode.tar.gz; \
+    echo "${opencode_sha256}  /tmp/opencode.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/opencode.tar.gz -C /tmp; \
+    install -m 0755 /tmp/opencode /usr/local/bin/opencode; \
+    rm -f /tmp/opencode /tmp/opencode.tar.gz
 
 RUN useradd --create-home --shell /bin/bash agent22 \
     && mkdir -p /home/agent22/.local/share/opencode /home/agent22/.opencode /home/agent22/.ssh /workspace \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Agent22 is an opinionated Go automation service for handling work items and pull/merge requests with a CLI coding agent. It runs as a continuous loop on a machine that has repository access, work-provider access (JIRA or GitHub Issues), SCM access (Gitea, GitLab, or GitHub), and a supported coding-agent CLI available.
 
+> Note: this GitHub repository is a mirror of the primary repository hosted on a personal Gitea instance.
+
 [![Watch the Agent22 demo](.github/assets/agent22.png)](.github/assets/agent22.webm)
 
 ## Why This Project Exists

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Agent22</h1>
 
-Agent22 is an opinionated Go automation service for handling JIRA tickets and pull/merge requests with a CLI coding agent. It runs as a continuous loop on a machine that has repository access, JIRA access, SCM access (Gitea or GitLab), and a supported coding-agent CLI available.
+Agent22 is an opinionated Go automation service for handling work items and pull/merge requests with a CLI coding agent. It runs as a continuous loop on a machine that has repository access, work-provider access (JIRA or GitHub Issues), SCM access (Gitea, GitLab, or GitHub), and a supported coding-agent CLI available.
 
 [![Watch the Agent22 demo](.github/assets/agent22.png)](.github/assets/agent22.webm)
 
@@ -30,14 +30,14 @@ Before running Agent22, make sure:
 
 Agent22 supports two modes:
 
-- `ticket mode` (default): polls JIRA and drives branch/PR automation from issues.
+- `ticket mode` (default): polls the configured work provider and drives branch/PR automation from issues.
 - `pull request mode` (`--pull-request-mode`): monitors open pull/merge requests and applies new review comments with the configured coding agent.
 
 ## Ticket Mode Flow
 
-For each matching JIRA issue, Agent22:
+For each matching issue, Agent22:
 
-1. Searches JIRA using your configured JQL.
+1. Searches your configured work provider (JIRA JQL or GitHub issue labels).
 2. Syncs the base branch locally.
 3. Creates or checks out an issue branch (`<ISSUE-KEY>`).
 4. Builds a coding-agent prompt from:
@@ -51,7 +51,7 @@ For each matching JIRA issue, Agent22:
 8. Stages and commits local changes (if any non-sensitive files changed).
 9. Pushes the issue branch.
 10. Creates a pull/merge request (or reuses an existing open one).
-11. Transitions the JIRA issue to the configured done status.
+11. Marks the issue as done (JIRA transition or GitHub done label).
 12. Returns to the configured base branch and continues.
 
 ### Ticket Filtering
@@ -77,12 +77,13 @@ When started with `--pull-request-mode`, Agent22:
 
 ## Console Output
 
-- The JIRA task prompt is displayed in an ASCII box for easier visual scanning.
+- The issue task prompt is displayed in an ASCII box for easier visual scanning.
 - Coding-agent execution uses a progress bar and spinner.
 
 ## Integrations
 
 - JIRA
+- GitHub Issues
 - Gitea
 - GitLab
 - GitHub
@@ -96,7 +97,7 @@ Copy `.agent22.example.yml` to `.agent22.yml` and fill in your values.
 Example:
 
 ```yaml
-work_provider: "jira"
+work_provider: "jira" # supported: jira, github
 scm_provider: "gitea" # supported: gitea, gitlab, github
 coding_agent_provider: "opencode" # supported: opencode, cursor
 wait_time_seconds: 30
@@ -112,6 +113,11 @@ jira:
   max_results: 25
   pr_status: "PR Ready"
   done_status: "Done"
+
+github_work:
+  labels: ["ready"]
+  in_progress_label: "in-progress"
+  done_label: "done"
 
 git_repo: "your-repo"
 git_base_branch: "main"
@@ -134,9 +140,11 @@ Notes:
 
 - `wait_time_seconds` defaults to `30` when omitted or <= 0.
 - Polling in both modes uses exponential idle backoff (capped at 10 minutes) and resets after work is found.
-- `work_provider` currently supports `jira`.
+- `work_provider` supports `jira` and `github`.
 - `scm_provider` defaults to `gitea` when omitted.
 - `coding_agent_provider` defaults to `opencode` when omitted.
+- For `work_provider: "jira"`, configure the `jira` block (`base_url`, `email`, `api_token`, `jql`, and `done_status`).
+- For `work_provider: "github"`, configure `github_owner`, `github_token`, `git_repo`, and `github_work.labels` + `github_work.done_label`.
 - For `gitea`, configure `gitea_owner`, `gitea_token`, and `gitea_base_url`.
 - For `gitlab`, configure `gitlab_token`, `gitlab_base_url`, and `gitlab_project_path`.
 - For `github`, configure `github_owner`, `github_token`, and `git_repo` (optionally `github_base_url` for GitHub Enterprise).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Agent22 is an opinionated Go automation service for handling work items and pull/merge requests with a CLI coding agent. It runs as a continuous loop on a machine that has repository access, work-provider access (JIRA or GitHub Issues), SCM access (Gitea, GitLab, or GitHub), and a supported coding-agent CLI available.
 
-> Note: this GitHub repository is a mirror of the primary repository hosted on a personal Gitea instance.
+> Note: this GitHub repository is a read-only mirror of the primary repository hosted on a personal Gitea instance.
+> For canonical updates, releases, and source of truth, use the Gitea repository.
 
 [![Watch the Agent22 demo](.github/assets/agent22.png)](.github/assets/agent22.webm)
 
@@ -147,6 +148,7 @@ Notes:
 - `coding_agent_provider` defaults to `opencode` when omitted.
 - For `work_provider: "jira"`, configure the `jira` block (`base_url`, `email`, `api_token`, `jql`, and `done_status`).
 - For `work_provider: "github"`, configure `github_owner`, `github_token`, `git_repo`, and `github_work.labels` + `github_work.done_label`.
+- GitHub issue keys are normalized to the canonical `GH-<number>` format (for example, `gh-42` resolves to `GH-42`).
 - For `gitea`, configure `gitea_owner`, `gitea_token`, and `gitea_base_url`.
 - For `gitlab`, configure `gitlab_token`, `gitlab_base_url`, and `gitlab_project_path`.
 - For `github`, configure `github_owner`, `github_token`, and `git_repo` (optionally `github_base_url` for GitHub Enterprise).

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -16,7 +16,8 @@ type AgentConfig struct {
 	SCMProvider         string `yaml:"scm_provider"`
 	CodingAgentProvider string `yaml:"coding_agent_provider"`
 
-	Jira *JiraConfig `yaml:"jira"`
+	Jira       *JiraConfig       `yaml:"jira"`
+	GitHubWork *GitHubWorkConfig `yaml:"github_work"`
 
 	WaitTimeSeconds int `yaml:"wait_time_seconds"`
 
@@ -46,7 +47,10 @@ func RunAgent(config AgentConfig) error {
 
 	httpClient := &http.Client{Timeout: 20 * time.Second}
 
-	var tracker IssueProvider = NewJiraClient(httpClient, config.Jira)
+	tracker, err := NewIssueProvider(httpClient, config)
+	if err != nil {
+		return fmt.Errorf("build issue provider: %w", err)
+	}
 
 	scm, err := NewPullRequestProvider(httpClient, config)
 	if err != nil {
@@ -61,7 +65,7 @@ func RunAgent(config AgentConfig) error {
 	cache := &ResultCache{}
 
 	return runPollingEventLoop(pollingEventLoopConfig{
-		Name:        "jira issue",
+		Name:        "work item",
 		BaseWait:    time.Duration(config.WaitTimeSeconds) * time.Second,
 		MaxIdleWait: 10 * time.Minute,
 	}, func(ctx context.Context) (bool, error) {
@@ -121,6 +125,11 @@ func processIssue(
 	cache *ResultCache,
 	issue Issue,
 ) error {
+	if err := tracker.MarkIssueInProgress(ctx, issue.Key); err != nil {
+		slog.Warn("Failed to transition issue to in-progress", "issue", issue.Key, "error", err)
+		outputWarnf("Unable to mark issue %s as in progress; continuing", issue.Key)
+	}
+
 	if err := SyncBaseBranch(config.GitRemote, config.GitBaseBranch); err != nil {
 		return fmt.Errorf("sync base branch for issue %s: %w", issue.Key, err)
 	}

--- a/internal/config_validation_test.go
+++ b/internal/config_validation_test.go
@@ -69,6 +69,80 @@ func TestRunModeConfigValidationUsesSharedSCMRules(t *testing.T) {
 	}
 }
 
+func TestRunAgentConfigValidationGitHubWorkProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mutate        func(cfg *agentinternal.AgentConfig)
+		expectedError string
+	}{
+		{
+			name: "missing github work block",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GitHubWork = nil
+			},
+			expectedError: "github config: github_work block is required",
+		},
+		{
+			name: "missing github done label",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GitHubWork.DoneLabel = ""
+			},
+			expectedError: "github config: github_work.done_label is required",
+		},
+		{
+			name: "missing github selection labels",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GitHubWork.Labels = nil
+			},
+			expectedError: "github config: github_work.labels must contain at least one label",
+		},
+		{
+			name: "missing github owner in ticket mode",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GithubOwner = ""
+			},
+			expectedError: "github config: github_owner is required",
+		},
+		{
+			name: "missing github token in ticket mode",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GithubToken = ""
+			},
+			expectedError: "github config: github_token is required",
+		},
+		{
+			name: "missing git repo in ticket mode",
+			mutate: func(cfg *agentinternal.AgentConfig) {
+				cfg.WorkProvider = "github"
+				cfg.GitRepo = ""
+			},
+			expectedError: "github config: git_repo is required",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := validAgentConfig()
+			tc.mutate(&cfg)
+
+			err := agentinternal.RunAgent(cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+				t.Fatalf("RunAgent error = %v, want contains %q", err, tc.expectedError)
+			}
+		})
+	}
+}
+
 func validAgentConfig() agentinternal.AgentConfig {
 	return agentinternal.AgentConfig{
 		WorkProvider: "jira",
@@ -93,5 +167,9 @@ func validAgentConfig() agentinternal.AgentConfig {
 		GithubOwner:       "owner",
 		GithubToken:       "token",
 		GithubBaseURL:     "https://api.github.com",
+		GitHubWork: &agentinternal.GitHubWorkConfig{
+			Labels:    []string{"ready"},
+			DoneLabel: "done",
+		},
 	}
 }

--- a/internal/github_issue.go
+++ b/internal/github_issue.go
@@ -134,7 +134,7 @@ func (c *GitHubIssueClient) addIssueLabel(ctx context.Context, issueKey, label, 
 
 	issueNumber, err := c.resolveIssueNumber(issueKey)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve github issue number for %s: %w", operation, err)
 	}
 
 	endpoint := c.client.repoEndpoint(fmt.Sprintf("issues/%d/labels", issueNumber))
@@ -149,24 +149,32 @@ func (c *GitHubIssueClient) addIssueLabel(ctx context.Context, issueKey, label, 
 }
 
 func (c *GitHubIssueClient) resolveIssueNumber(issueKey string) (int, error) {
-	if number, ok := c.issueNumbers[issueKey]; ok {
+	normalizedKey, err := normalizeGitHubIssueKey(issueKey)
+	if err != nil {
+		return 0, err
+	}
+
+	if number, ok := c.issueNumbers[normalizedKey]; ok {
 		return number, nil
 	}
 
+	return 0, fmt.Errorf("unknown github issue key %q: not found in current search results", issueKey)
+}
+
+func normalizeGitHubIssueKey(issueKey string) (string, error) {
 	trimmed := strings.TrimSpace(issueKey)
-	trimmed = strings.TrimPrefix(trimmed, "#")
-
-	upper := strings.ToUpper(trimmed)
-	if strings.HasPrefix(upper, gitHubIssueKeyPrefix) {
-		trimmed = strings.TrimSpace(trimmed[len(gitHubIssueKeyPrefix):])
+	if !strings.HasPrefix(trimmed, gitHubIssueKeyPrefix) {
+		return "", fmt.Errorf("parse github issue key %q: expected %s<number>", issueKey, gitHubIssueKeyPrefix)
 	}
 
-	number, err := strconv.Atoi(trimmed)
+	numberPart := strings.TrimSpace(strings.TrimPrefix(trimmed, gitHubIssueKeyPrefix))
+
+	number, err := strconv.Atoi(numberPart)
 	if err != nil {
-		return 0, fmt.Errorf("parse github issue key %q: %w", issueKey, err)
+		return "", fmt.Errorf("parse github issue key %q: %w", issueKey, err)
 	}
 
-	return number, nil
+	return formatGitHubIssueKey(number), nil
 }
 
 func formatGitHubIssueKey(issueNumber int) string {

--- a/internal/github_issue.go
+++ b/internal/github_issue.go
@@ -25,7 +25,8 @@ type GitHubIssueClient struct {
 	labels          []string
 	inProgressLabel string
 	doneLabel       string
-	issueNumbers    map[string]int
+	// issueNumbers caches keys from the latest SearchIssues call; callers are expected to use this client from a single goroutine.
+	issueNumbers map[string]int
 }
 
 type gitHubIssueResponse struct {
@@ -163,11 +164,11 @@ func (c *GitHubIssueClient) resolveIssueNumber(issueKey string) (int, error) {
 
 func normalizeGitHubIssueKey(issueKey string) (string, error) {
 	trimmed := strings.TrimSpace(issueKey)
-	if !strings.HasPrefix(trimmed, gitHubIssueKeyPrefix) {
+	if len(trimmed) < len(gitHubIssueKeyPrefix) || !strings.EqualFold(trimmed[:len(gitHubIssueKeyPrefix)], gitHubIssueKeyPrefix) {
 		return "", fmt.Errorf("parse github issue key %q: expected %s<number>", issueKey, gitHubIssueKeyPrefix)
 	}
 
-	numberPart := strings.TrimSpace(strings.TrimPrefix(trimmed, gitHubIssueKeyPrefix))
+	numberPart := strings.TrimSpace(trimmed[len(gitHubIssueKeyPrefix):])
 
 	number, err := strconv.Atoi(numberPart)
 	if err != nil {

--- a/internal/github_issue.go
+++ b/internal/github_issue.go
@@ -1,0 +1,221 @@
+// Package internal implements a GitHub issue-based work provider.
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const gitHubIssueKeyPrefix = "GH-"
+
+var _ IssueProvider = (*GitHubIssueClient)(nil)
+
+type GitHubWorkConfig struct {
+	Labels          []string `yaml:"labels"`
+	InProgressLabel string   `yaml:"in_progress_label"`
+	DoneLabel       string   `yaml:"done_label"`
+}
+
+type GitHubIssueClient struct {
+	client          *GitHubClient
+	labels          []string
+	inProgressLabel string
+	doneLabel       string
+	issueNumbers    map[string]int
+}
+
+type gitHubIssueResponse struct {
+	ID          int64              `json:"id"`
+	Number      int                `json:"number"`
+	Title       string             `json:"title"`
+	Body        string             `json:"body"`
+	Labels      []gitHubIssueLabel `json:"labels"`
+	PullRequest *struct{}          `json:"pull_request,omitempty"`
+}
+
+type gitHubIssueLabel struct {
+	Name string `json:"name"`
+}
+
+type gitHubIssueLabelsRequest struct {
+	Labels []string `json:"labels"`
+}
+
+func NewGitHubIssueClient(
+	httpClient *http.Client,
+	baseURL, token, owner, repo string,
+	cfg *GitHubWorkConfig,
+) *GitHubIssueClient {
+	labels := make([]string, 0)
+	inProgressLabel := ""
+	doneLabel := ""
+
+	if cfg != nil {
+		labels = trimAndDeduplicateLabels(cfg.Labels)
+		inProgressLabel = strings.TrimSpace(cfg.InProgressLabel)
+		doneLabel = strings.TrimSpace(cfg.DoneLabel)
+	}
+
+	return &GitHubIssueClient{
+		client:          NewGitHubClient(httpClient, baseURL, token, owner, repo),
+		labels:          labels,
+		inProgressLabel: inProgressLabel,
+		doneLabel:       doneLabel,
+		issueNumbers:    make(map[string]int),
+	}
+}
+
+func (c *GitHubIssueClient) SearchIssues(ctx context.Context) ([]Issue, error) {
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("labels", strings.Join(c.labels, ","))
+
+	baseEndpoint := c.client.repoEndpoint("issues") + "?" + query.Encode()
+
+	issues, err := listAllGitHubPages[gitHubIssueResponse](ctx, c.client, baseEndpoint, "issue search")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Issue, 0, len(issues))
+	issueNumbers := make(map[string]int, len(issues))
+
+	for _, issue := range issues {
+		if issue.PullRequest != nil {
+			continue
+		}
+
+		key := formatGitHubIssueKey(issue.Number)
+		issueNumbers[key] = issue.Number
+
+		result = append(result, Issue{
+			ID:          strconv.Itoa(issue.Number),
+			Key:         key,
+			Summary:     strings.TrimSpace(issue.Title),
+			Status:      formatGitHubIssueStatus(issue.Labels),
+			Description: strings.TrimSpace(issue.Body),
+		})
+	}
+
+	c.issueNumbers = issueNumbers
+
+	return result, nil
+}
+
+func (c *GitHubIssueClient) MarkIssueInProgress(ctx context.Context, issueKey string) error {
+	if strings.TrimSpace(c.inProgressLabel) == "" {
+		return nil
+	}
+
+	if err := c.addIssueLabel(ctx, issueKey, c.inProgressLabel, "in-progress label update"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *GitHubIssueClient) MarkIssueDone(ctx context.Context, issueKey string) error {
+	if err := c.addIssueLabel(ctx, issueKey, c.doneLabel, "done label update"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *GitHubIssueClient) addIssueLabel(ctx context.Context, issueKey, label, operation string) error {
+	trimmedLabel := strings.TrimSpace(label)
+	if trimmedLabel == "" {
+		return nil
+	}
+
+	issueNumber, err := c.resolveIssueNumber(issueKey)
+	if err != nil {
+		return err
+	}
+
+	endpoint := c.client.repoEndpoint(fmt.Sprintf("issues/%d/labels", issueNumber))
+
+	payload := gitHubIssueLabelsRequest{Labels: []string{trimmedLabel}}
+
+	if err := c.client.doJSON(ctx, http.MethodPost, endpoint, payload, nil, operation); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *GitHubIssueClient) resolveIssueNumber(issueKey string) (int, error) {
+	if number, ok := c.issueNumbers[issueKey]; ok {
+		return number, nil
+	}
+
+	trimmed := strings.TrimSpace(issueKey)
+	trimmed = strings.TrimPrefix(trimmed, "#")
+
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix(upper, gitHubIssueKeyPrefix) {
+		trimmed = strings.TrimSpace(trimmed[len(gitHubIssueKeyPrefix):])
+	}
+
+	number, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("parse github issue key %q: %w", issueKey, err)
+	}
+
+	return number, nil
+}
+
+func formatGitHubIssueKey(issueNumber int) string {
+	return fmt.Sprintf("%s%d", gitHubIssueKeyPrefix, issueNumber)
+}
+
+func formatGitHubIssueStatus(labels []gitHubIssueLabel) string {
+	statusLabels := make([]string, 0, len(labels))
+	for _, label := range labels {
+		name := strings.TrimSpace(label.Name)
+		if name == "" {
+			continue
+		}
+
+		statusLabels = append(statusLabels, name)
+	}
+
+	if len(statusLabels) == 0 {
+		return "open"
+	}
+
+	return strings.Join(statusLabels, ", ")
+}
+
+func trimAndDeduplicateLabels(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(labels))
+
+	result := make([]string, 0, len(labels))
+
+	for _, label := range labels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" {
+			continue
+		}
+
+		normalized := strings.ToLower(trimmed)
+
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+
+		seen[normalized] = struct{}{}
+
+		result = append(result, trimmed)
+	}
+
+	return result
+}

--- a/internal/github_issue_test.go
+++ b/internal/github_issue_test.go
@@ -1,0 +1,315 @@
+// Package internal_test verifies the GitHub issue provider behavior.
+package internal_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	agentinternal "gitea.lan/cubixle/agent/internal"
+)
+
+func TestGitHubIssueClientSearchAndMarkDone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var postedLabels []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/repo/issues":
+			if got := r.URL.Query().Get("state"); got != "open" {
+				t.Fatalf("state query = %q, want %q", got, "open")
+			}
+
+			if got := r.URL.Query().Get("labels"); got != "ready" {
+				t.Fatalf("labels query = %q, want %q", got, "ready")
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[
+				{"id": 1, "number": 101, "title": "Implement provider", "body": "Build it", "labels": [{"name": "ready"}]},
+				{"id": 2, "number": 202, "title": "PR mirror", "body": "", "labels": [{"name": "ready"}], "pull_request": {"url": "x"}}
+			]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/repo/issues/101/labels":
+			defer r.Body.Close()
+
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode label payload: %v", err)
+			}
+
+			postedLabels = payload.Labels
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels:    []string{"ready"},
+		DoneLabel: "done",
+	})
+
+	issues, err := client.SearchIssues(ctx)
+	if err != nil {
+		t.Fatalf("SearchIssues() error = %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("len(issues) = %d, want 1", len(issues))
+	}
+
+	if issues[0].Key != "GH-101" {
+		t.Fatalf("issue key = %q, want %q", issues[0].Key, "GH-101")
+	}
+
+	if err := client.MarkIssueDone(ctx, issues[0].Key); err != nil {
+		t.Fatalf("MarkIssueDone() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(postedLabels, []string{"done"}) {
+		t.Fatalf("posted labels = %v, want %v", postedLabels, []string{"done"})
+	}
+}
+
+func TestGitHubIssueClientMarkDoneParsesNumericKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	receivedPath := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels:    []string{"ready"},
+		DoneLabel: "done",
+	})
+
+	if err := client.MarkIssueDone(ctx, "42"); err != nil {
+		t.Fatalf("MarkIssueDone() error = %v", err)
+	}
+
+	if receivedPath != "/repos/acme/repo/issues/42/labels" {
+		t.Fatalf("request path = %q, want %q", receivedPath, "/repos/acme/repo/issues/42/labels")
+	}
+}
+
+func TestGitHubIssueClientMarkIssueInProgress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		inProgressLabel string
+		wantCalls       int
+		wantLabels      []string
+	}{
+		{
+			name:            "adds configured in-progress label",
+			inProgressLabel: "in-progress",
+			wantCalls:       1,
+			wantLabels:      []string{"in-progress"},
+		},
+		{
+			name:            "skips when in-progress label empty",
+			inProgressLabel: "   ",
+			wantCalls:       0,
+			wantLabels:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			calls := 0
+			var postedLabels []string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				if r.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", r.Method)
+				}
+
+				if r.URL.Path != "/repos/acme/repo/issues/101/labels" {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, "/repos/acme/repo/issues/101/labels")
+				}
+
+				defer r.Body.Close()
+
+				var payload struct {
+					Labels []string `json:"labels"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode label payload: %v", err)
+				}
+
+				calls++
+				postedLabels = payload.Labels
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer server.Close()
+
+			client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+				Labels:          []string{"ready"},
+				InProgressLabel: tc.inProgressLabel,
+				DoneLabel:       "done",
+			})
+
+			if err := client.MarkIssueInProgress(ctx, "GH-101"); err != nil {
+				t.Fatalf("MarkIssueInProgress() error = %v", err)
+			}
+
+			if calls != tc.wantCalls {
+				t.Fatalf("label post calls = %d, want %d", calls, tc.wantCalls)
+			}
+
+			if !reflect.DeepEqual(postedLabels, tc.wantLabels) {
+				t.Fatalf("posted labels = %v, want %v", postedLabels, tc.wantLabels)
+			}
+		})
+	}
+}
+
+func TestGitHubIssueClientSearchIssuesPagination(t *testing.T) {
+	t.Parallel()
+
+	const firstPageSize = 50
+
+	ctx := context.Background()
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+
+		if r.URL.Path != "/repos/acme/repo/issues" {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, "/repos/acme/repo/issues")
+		}
+
+		if got := r.URL.Query().Get("state"); got != "open" {
+			t.Fatalf("state query = %q, want %q", got, "open")
+		}
+
+		if got := r.URL.Query().Get("labels"); got != "ready" {
+			t.Fatalf("labels query = %q, want %q", got, "ready")
+		}
+
+		page := r.URL.Query().Get("page")
+		perPage := r.URL.Query().Get("per_page")
+		if perPage != "50" {
+			t.Fatalf("per_page query = %q, want %q", perPage, "50")
+		}
+
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch page {
+		case "1":
+			rows := make([]string, 0, firstPageSize)
+			for i := 1; i <= firstPageSize; i++ {
+				rows = append(rows, fmt.Sprintf(`{"id": %d, "number": %d, "title": "Issue %d", "body": "body", "labels": [{"name": "ready"}]}`,
+					i,
+					i,
+					i,
+				))
+			}
+
+			_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+		case "2":
+			_, _ = w.Write([]byte(`[
+				{"id": 101, "number": 101, "title": "Issue 101", "body": "body", "labels": [{"name": "ready"}]},
+				{"id": 102, "number": 102, "title": "Issue 102", "body": "body", "labels": [{"name": "ready"}]}
+			]`))
+		default:
+			t.Fatalf("unexpected page query = %q", page)
+		}
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels:    []string{"ready"},
+		DoneLabel: "done",
+	})
+
+	issues, err := client.SearchIssues(ctx)
+	if err != nil {
+		t.Fatalf("SearchIssues() error = %v", err)
+	}
+
+	if requests != 2 {
+		t.Fatalf("request count = %d, want 2", requests)
+	}
+
+	if len(issues) != 52 {
+		t.Fatalf("len(issues) = %d, want 52", len(issues))
+	}
+
+	if issues[0].Key != "GH-1" {
+		t.Fatalf("first issue key = %q, want %q", issues[0].Key, "GH-1")
+	}
+
+	if issues[len(issues)-1].Key != "GH-102" {
+		t.Fatalf("last issue key = %q, want %q", issues[len(issues)-1].Key, "GH-102")
+	}
+}
+
+func TestNewGitHubIssueClientTrimAndDeduplicateLabelsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+
+		gotLabels := r.URL.Query().Get("labels")
+		if gotLabels != "Ready,DONE" {
+			t.Fatalf("labels query = %q, want %q", gotLabels, "Ready,DONE")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels: []string{"Ready", "ready", " DONE ", "done"},
+	})
+
+	if _, err := client.SearchIssues(ctx); err != nil {
+		t.Fatalf("SearchIssues() error = %v", err)
+	}
+}

--- a/internal/github_issue_test.go
+++ b/internal/github_issue_test.go
@@ -4,6 +4,7 @@ package internal_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ func TestGitHubIssueClientSearchAndMarkDone(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
+		assertGitHubRequestHeaders(t, r)
 
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/repo/issues":
@@ -84,22 +86,73 @@ func TestGitHubIssueClientSearchAndMarkDone(t *testing.T) {
 	}
 }
 
-func TestGitHubIssueClientMarkDoneParsesNumericKey(t *testing.T) {
+func TestGitHubIssueClientMarkDoneStrictIssueKeyFormat(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	receivedPath := ""
+
+	client := agentinternal.NewGitHubIssueClient(&http.Client{}, "https://api.github.com", "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels:    []string{"ready"},
+		DoneLabel: "done",
+	})
+
+	tests := []struct {
+		name          string
+		issueKey      string
+		expectedError string
+	}{
+		{
+			name:          "plain number",
+			issueKey:      "42",
+			expectedError: "expected GH-<number>",
+		},
+		{
+			name:          "hash prefix",
+			issueKey:      "#42",
+			expectedError: "expected GH-<number>",
+		},
+		{
+			name:          "lowercase prefix",
+			issueKey:      "gh-42",
+			expectedError: "expected GH-<number>",
+		},
+		{
+			name:          "non numeric suffix",
+			issueKey:      "GH-abc",
+			expectedError: "invalid syntax",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := client.MarkIssueDone(ctx, tc.issueKey)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+				t.Fatalf("MarkIssueDone() error = %v, want contains %q", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestGitHubIssueClientMarkDoneUnknownIssueKeyFailsFast(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
+		assertGitHubRequestHeaders(t, r)
 
-		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
 		}
 
-		receivedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`[
+			{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+		]`))
 	}))
 	defer server.Close()
 
@@ -108,12 +161,13 @@ func TestGitHubIssueClientMarkDoneParsesNumericKey(t *testing.T) {
 		DoneLabel: "done",
 	})
 
-	if err := client.MarkIssueDone(ctx, "42"); err != nil {
-		t.Fatalf("MarkIssueDone() error = %v", err)
+	if _, err := client.SearchIssues(ctx); err != nil {
+		t.Fatalf("SearchIssues() error = %v", err)
 	}
 
-	if receivedPath != "/repos/acme/repo/issues/42/labels" {
-		t.Fatalf("request path = %q, want %q", receivedPath, "/repos/acme/repo/issues/42/labels")
+	err := client.MarkIssueDone(ctx, "GH-999")
+	if err == nil || !strings.Contains(err.Error(), `unknown github issue key "GH-999"`) {
+		t.Fatalf("MarkIssueDone() error = %v, want unknown key error", err)
 	}
 }
 
@@ -151,28 +205,35 @@ func TestGitHubIssueClientMarkIssueInProgress(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				t.Helper()
+				assertGitHubRequestHeaders(t, r)
 
-				if r.Method != http.MethodPost {
-					t.Fatalf("method = %s, want POST", r.Method)
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`[
+						{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+					]`))
+				case http.MethodPost:
+					if r.URL.Path != "/repos/acme/repo/issues/101/labels" {
+						t.Fatalf("request path = %q, want %q", r.URL.Path, "/repos/acme/repo/issues/101/labels")
+					}
+
+					defer r.Body.Close()
+
+					var payload struct {
+						Labels []string `json:"labels"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode label payload: %v", err)
+					}
+
+					calls++
+					postedLabels = payload.Labels
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`[]`))
+				default:
+					t.Fatalf("unexpected method = %s", r.Method)
 				}
-
-				if r.URL.Path != "/repos/acme/repo/issues/101/labels" {
-					t.Fatalf("request path = %q, want %q", r.URL.Path, "/repos/acme/repo/issues/101/labels")
-				}
-
-				defer r.Body.Close()
-
-				var payload struct {
-					Labels []string `json:"labels"`
-				}
-				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-					t.Fatalf("decode label payload: %v", err)
-				}
-
-				calls++
-				postedLabels = payload.Labels
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`[]`))
 			}))
 			defer server.Close()
 
@@ -182,7 +243,11 @@ func TestGitHubIssueClientMarkIssueInProgress(t *testing.T) {
 				DoneLabel:       "done",
 			})
 
-			if err := client.MarkIssueInProgress(ctx, "GH-101"); err != nil {
+			if _, err := client.SearchIssues(ctx); err != nil {
+				t.Fatalf("SearchIssues() error = %v", err)
+			}
+
+			if err := client.MarkIssueInProgress(ctx, " GH-101 "); err != nil {
 				t.Fatalf("MarkIssueInProgress() error = %v", err)
 			}
 
@@ -207,6 +272,7 @@ func TestGitHubIssueClientSearchIssuesPagination(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
+		assertGitHubRequestHeaders(t, r)
 
 		if r.Method != http.MethodGet {
 			t.Fatalf("method = %s, want GET", r.Method)
@@ -290,6 +356,7 @@ func TestNewGitHubIssueClientTrimAndDeduplicateLabelsCaseInsensitive(t *testing.
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
+		assertGitHubRequestHeaders(t, r)
 
 		if r.Method != http.MethodGet {
 			t.Fatalf("method = %s, want GET", r.Method)
@@ -312,4 +379,161 @@ func TestNewGitHubIssueClientTrimAndDeduplicateLabelsCaseInsensitive(t *testing.
 	if _, err := client.SearchIssues(ctx); err != nil {
 		t.Fatalf("SearchIssues() error = %v", err)
 	}
+}
+
+func TestGitHubIssueClientSearchIssuesErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		baseURL       string
+		httpClient    *http.Client
+		handler       http.HandlerFunc
+		expectedError string
+	}{
+		{
+			name: "non 2xx status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`upstream`))
+			},
+			expectedError: "github issue search failed: status=502 Bad Gateway body=upstream",
+		},
+		{
+			name: "malformed json",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"broken":`))
+			},
+			expectedError: "decode github issue search response",
+		},
+		{
+			name:          "transport error",
+			baseURL:       "https://api.github.com",
+			httpClient:    &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("network down") })},
+			expectedError: "network down",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseURL := tc.baseURL
+			httpClient := tc.httpClient
+
+			if tc.handler != nil {
+				server := httptest.NewServer(tc.handler)
+				defer server.Close()
+				baseURL = server.URL
+				httpClient = server.Client()
+			}
+
+			client := agentinternal.NewGitHubIssueClient(httpClient, baseURL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+				Labels: []string{"ready"},
+			})
+
+			_, err := client.SearchIssues(ctx)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+				t.Fatalf("SearchIssues() error = %v, want contains %q", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestGitHubIssueClientMarkIssueLabelErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		issueKey      string
+		handler       http.HandlerFunc
+		expectedError string
+	}{
+		{
+			name:     "unknown issue key",
+			issueKey: "GH-999",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[
+					{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+				]`))
+			},
+			expectedError: `resolve github issue number for done label update: unknown github issue key "GH-999"`,
+		},
+		{
+			name:     "label update non 2xx",
+			issueKey: "GH-101",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`[
+						{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+					]`))
+				case http.MethodPost:
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte("bad token"))
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			},
+			expectedError: "github done label update failed: status=401 Unauthorized body=bad token",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				assertGitHubRequestHeaders(t, r)
+				tc.handler(w, r)
+			}))
+			defer server.Close()
+
+			client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+				Labels:    []string{"ready"},
+				DoneLabel: "done",
+			})
+
+			if _, err := client.SearchIssues(ctx); err != nil {
+				t.Fatalf("SearchIssues() error = %v", err)
+			}
+
+			err := client.MarkIssueDone(ctx, tc.issueKey)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+				t.Fatalf("MarkIssueDone() error = %v, want contains %q", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func assertGitHubRequestHeaders(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	if got := r.Header.Get("Authorization"); got != "Bearer token" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer token")
+	}
+
+	if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+		t.Fatalf("Accept header = %q, want %q", got, "application/vnd.github+json")
+	}
+
+	if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+		t.Fatalf("X-GitHub-Api-Version header = %q, want %q", got, "2022-11-28")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/internal/github_issue_test.go
+++ b/internal/github_issue_test.go
@@ -86,7 +86,7 @@ func TestGitHubIssueClientSearchAndMarkDone(t *testing.T) {
 	}
 }
 
-func TestGitHubIssueClientMarkDoneStrictIssueKeyFormat(t *testing.T) {
+func TestGitHubIssueClientMarkDoneIssueKeyParsing(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -114,7 +114,7 @@ func TestGitHubIssueClientMarkDoneStrictIssueKeyFormat(t *testing.T) {
 		{
 			name:          "lowercase prefix",
 			issueKey:      "gh-42",
-			expectedError: "expected GH-<number>",
+			expectedError: `unknown github issue key "gh-42"`,
 		},
 		{
 			name:          "non numeric suffix",
@@ -131,6 +131,79 @@ func TestGitHubIssueClientMarkDoneStrictIssueKeyFormat(t *testing.T) {
 			err := client.MarkIssueDone(ctx, tc.issueKey)
 			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
 				t.Fatalf("MarkIssueDone() error = %v, want contains %q", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestGitHubIssueClientMarkIssueInProgressErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		issueKey      string
+		handler       http.HandlerFunc
+		expectedError string
+	}{
+		{
+			name:     "unknown issue key",
+			issueKey: "GH-999",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[
+					{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+				]`))
+			},
+			expectedError: `resolve github issue number for in-progress label update: unknown github issue key "GH-999"`,
+		},
+		{
+			name:     "label update non 2xx",
+			issueKey: "GH-101",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`[
+						{"id": 1, "number": 101, "title": "Issue 101", "body": "Body", "labels": [{"name": "ready"}]}
+					]`))
+				case http.MethodPost:
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte("bad token"))
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			},
+			expectedError: "github in-progress label update failed: status=401 Unauthorized body=bad token",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				assertGitHubRequestHeaders(t, r)
+				tc.handler(w, r)
+			}))
+			defer server.Close()
+
+			client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+				Labels:          []string{"ready"},
+				InProgressLabel: "in-progress",
+				DoneLabel:       "done",
+			})
+
+			if _, err := client.SearchIssues(ctx); err != nil {
+				t.Fatalf("SearchIssues() error = %v", err)
+			}
+
+			err := client.MarkIssueInProgress(ctx, tc.issueKey)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+				t.Fatalf("MarkIssueInProgress() error = %v, want contains %q", err, tc.expectedError)
 			}
 		})
 	}

--- a/internal/opencode.go
+++ b/internal/opencode.go
@@ -44,7 +44,7 @@ func buildIssueCodingAgentInput(issue Issue) string {
 
 func buildIssuePostImplementationReviewInput(issue Issue) string {
 	input := fmt.Sprintf(
-		"%s\n\n%s\n\nJIRA issue key:\n%s\n\nJIRA issue summary:\n%s\n\nReview the current local changes in this branch before push. Do not modify files in this step. Produce only review findings for a human engineer.",
+		"%s\n\n%s\n\nIssue key:\n%s\n\nIssue summary:\n%s\n\nReview the current local changes in this branch before push. Do not modify files in this step. Produce only review findings for a human engineer.",
 		codingAgentSafetyInstructions,
 		humanReadableReviewOutputInstructions,
 		issue.Key,
@@ -61,7 +61,7 @@ func buildIssueApplyReviewInput(issue Issue, reviewOutput string) string {
 	}
 
 	input := fmt.Sprintf(
-		"%s\n\nJIRA issue key:\n%s\n\nJIRA issue summary:\n%s\n\nApply the following review feedback to the current branch. Implement only concrete fixes. If there are no valid findings, keep files unchanged.\n\nReview feedback:\n%s",
+		"%s\n\nIssue key:\n%s\n\nIssue summary:\n%s\n\nApply the following review feedback to the current branch. Implement only concrete fixes. If there are no valid findings, keep files unchanged.\n\nReview feedback:\n%s",
 		codingAgentSafetyInstructions,
 		issue.Key,
 		issue.Summary,

--- a/internal/opencode.go
+++ b/internal/opencode.go
@@ -10,6 +10,7 @@ import (
 
 const codingAgentSafetyInstructions = `
 do not interact with GIT directly.
+you may run read-only git status and git diff when reviewing local changes.
 do not ask for human input.
 never run git clean (including -fd, -fdx, or -fdX) and never delete local config files like .env* or .agent22.yml.
 `

--- a/internal/opencode.go
+++ b/internal/opencode.go
@@ -10,7 +10,6 @@ import (
 
 const codingAgentSafetyInstructions = `
 do not interact with GIT directly.
-you may run read-only git status and git diff when reviewing local changes.
 do not ask for human input.
 never run git clean (including -fd, -fdx, or -fdX) and never delete local config files like .env* or .agent22.yml.
 `

--- a/internal/opencode_test.go
+++ b/internal/opencode_test.go
@@ -1,0 +1,37 @@
+// Package internal verifies prompt construction for coding-agent integrations.
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildIssuePostImplementationReviewInputSafetyInstructions(t *testing.T) {
+	t.Parallel()
+
+	issue := Issue{Key: "GH-1", Summary: "Need to test Github integration"}
+	input := buildIssuePostImplementationReviewInput(issue)
+
+	if !strings.Contains(input, "do not interact with GIT directly.") {
+		t.Fatalf("buildIssuePostImplementationReviewInput() missing git safety rule")
+	}
+
+	if strings.Contains(input, "you may run read-only git status and git diff") {
+		t.Fatalf("buildIssuePostImplementationReviewInput() unexpectedly allows direct git commands")
+	}
+}
+
+func TestBuildIssueApplyReviewInputSafetyInstructions(t *testing.T) {
+	t.Parallel()
+
+	issue := Issue{Key: "GH-1", Summary: "Need to test Github integration"}
+	input := buildIssueApplyReviewInput(issue, "- None")
+
+	if !strings.Contains(input, "do not interact with GIT directly.") {
+		t.Fatalf("buildIssueApplyReviewInput() missing git safety rule")
+	}
+
+	if strings.Contains(input, "you may run read-only git status and git diff") {
+		t.Fatalf("buildIssueApplyReviewInput() unexpectedly allows direct git commands")
+	}
+}

--- a/internal/providers.go
+++ b/internal/providers.go
@@ -22,6 +22,26 @@ type PullRequestProvider interface {
 	CreatePullRequestComment(ctx context.Context, pullNumber int, body string) error
 }
 
+func NewIssueProvider(httpClient *http.Client, config AgentConfig) (IssueProvider, error) {
+	workProvider := strings.ToLower(strings.TrimSpace(config.WorkProvider))
+
+	switch workProvider {
+	case "", "jira":
+		return NewJiraClient(httpClient, config.Jira), nil
+	case "github":
+		return NewGitHubIssueClient(
+			httpClient,
+			config.GithubBaseURL,
+			config.GithubToken,
+			config.GithubOwner,
+			config.GitRepo,
+			config.GitHubWork,
+		), nil
+	default:
+		return nil, fmt.Errorf("unsupported work_provider %q: expected jira or github", config.WorkProvider)
+	}
+}
+
 func NewPullRequestProvider(httpClient *http.Client, config AgentConfig) (PullRequestProvider, error) {
 	scmProvider := strings.ToLower(strings.TrimSpace(config.SCMProvider))
 

--- a/internal/validation.go
+++ b/internal/validation.go
@@ -12,12 +12,17 @@ func validateTicketModeConfig(config AgentConfig) error {
 		return fmt.Errorf("work_provider is required")
 	}
 
-	if workProvider != "jira" {
-		return fmt.Errorf("unsupported work_provider %q: only jira is supported", config.WorkProvider)
-	}
-
-	if err := validateRequiredJiraFields(config.Jira); err != nil {
-		return fmt.Errorf("jira config: %w", err)
+	switch workProvider {
+	case "jira":
+		if err := validateRequiredJiraFields(config.Jira); err != nil {
+			return fmt.Errorf("jira config: %w", err)
+		}
+	case "github":
+		if err := validateRequiredGitHubIssueFields(config); err != nil {
+			return fmt.Errorf("github config: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported work_provider %q: expected jira or github", config.WorkProvider)
 	}
 
 	if err := validateSharedSCMConfig(config); err != nil {
@@ -151,6 +156,34 @@ func validateRequiredJiraFields(jira *JiraConfig) error {
 		if strings.TrimSpace(field.value) == "" {
 			return fmt.Errorf("%s is required", field.name)
 		}
+	}
+
+	return nil
+}
+
+func validateRequiredGitHubIssueFields(config AgentConfig) error {
+	if config.GitHubWork == nil {
+		return fmt.Errorf("github_work block is required")
+	}
+
+	requiredGitHubFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "github_owner", value: config.GithubOwner},
+		{name: "github_token", value: config.GithubToken},
+		{name: "git_repo", value: config.GitRepo},
+		{name: "github_work.done_label", value: config.GitHubWork.DoneLabel},
+	}
+
+	for _, field := range requiredGitHubFields {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+
+	if len(trimAndDeduplicateLabels(config.GitHubWork.Labels)) == 0 {
+		return fmt.Errorf("github_work.labels must contain at least one label")
 	}
 
 	return nil


### PR DESCRIPTION
Automated merge request for GH-1

## Description
Need to test Github integration

## OpenCode output

```text
[0m
> build · gpt-5.3-codex
[0m
[0m✱ [0mGlob "**/README*"[90m in . · 1 match[0m
[0m✱ [0mGlob "**/*.go"[90m in . · 22 matches[0m
[0m→ [0mRead README.md
[0m⚙ [0mapply_patch Success. Updated the following files:
M README.md
[0m
[0m$ [0mgo test ./...
?   	gitea.lan/cubixle/agent	[no test files]
ok  	gitea.lan/cubixle/agent/internal	(cached)
[0m
[0m$ [0mgolangci-lint run
0 issues.
[0m
Updated the README to clearly state this repo is a mirror of your personal Gitea instance.

- Added a visible note right under the project intro in `README.md:9` indicating GitHub is a mirror of the primary personal Gitea repo.

Also ran the integration checks you asked for:

- `go test ./...` passed
- `golangci-lint run` passed with `0 issues`
```