### PR TITLE
GH-1: Need to test Github integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Agent22 is an opinionated Go automation service for handling work items and pull/merge requests with a CLI coding agent. It runs as a continuous loop on a machine that has repository access, work-provider access (JIRA or GitHub Issues), SCM access (Gitea, GitLab, or GitHub), and a supported coding-agent CLI available.
 
+## Mirror Notice
+
+This repository is a read-only mirror of a personal Gitea instance.
+
 [![Watch the Agent22 demo](.github/assets/agent22.png)](.github/assets/agent22.webm)
 
 ## Why This Project Exists

--- a/internal/github_issue_test.go
+++ b/internal/github_issue_test.go
@@ -23,6 +23,18 @@ func TestGitHubIssueClientSearchAndMarkDone(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
 
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("authorization header = %q, want %q", got, "Bearer token")
+		}
+
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("accept header = %q, want %q", got, "application/vnd.github+json")
+		}
+
+		if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+			t.Fatalf("api version header = %q, want %q", got, "2022-11-28")
+		}
+
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/repo/issues":
 			if got := r.URL.Query().Get("state"); got != "open" {
@@ -357,5 +369,251 @@ func TestGitHubIssueClientSearchIssuesSkipsInProgressAndDone(t *testing.T) {
 
 	if issues[0].Key != "GH-101" {
 		t.Fatalf("issue key = %q, want %q", issues[0].Key, "GH-101")
+	}
+}
+
+func TestGitHubIssueClientMarkIssueActionsParseKeyVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		action    func(context.Context, *agentinternal.GitHubIssueClient, string) error
+		configure func(*agentinternal.GitHubWorkConfig)
+	}{
+		{
+			name: "mark done accepts numeric key variants",
+			action: func(ctx context.Context, client *agentinternal.GitHubIssueClient, issueKey string) error {
+				return client.MarkIssueDone(ctx, issueKey)
+			},
+			configure: func(cfg *agentinternal.GitHubWorkConfig) {
+				cfg.DoneLabel = "done"
+			},
+		},
+		{
+			name: "mark in-progress accepts numeric key variants",
+			action: func(ctx context.Context, client *agentinternal.GitHubIssueClient, issueKey string) error {
+				return client.MarkIssueInProgress(ctx, issueKey)
+			},
+			configure: func(cfg *agentinternal.GitHubWorkConfig) {
+				cfg.InProgressLabel = "in-progress"
+			},
+		},
+	}
+
+	keys := []string{"gh-42", "#42", "  GH-42  "}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, issueKey := range keys {
+				issueKey := issueKey
+				t.Run(issueKey, func(t *testing.T) {
+					t.Parallel()
+
+					ctx := context.Background()
+					receivedPath := ""
+
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						t.Helper()
+
+						if r.Method != http.MethodPost {
+							t.Fatalf("method = %s, want POST", r.Method)
+						}
+
+						receivedPath = r.URL.Path
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = w.Write([]byte(`[]`))
+					}))
+					defer server.Close()
+
+					cfg := &agentinternal.GitHubWorkConfig{}
+					tc.configure(cfg)
+
+					client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", cfg)
+
+					if err := tc.action(ctx, client, issueKey); err != nil {
+						t.Fatalf("action(%q) error = %v", issueKey, err)
+					}
+
+					if receivedPath != "/repos/acme/repo/issues/42/labels" {
+						t.Fatalf("request path = %q, want %q", receivedPath, "/repos/acme/repo/issues/42/labels")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestGitHubIssueClientSearchIssuesReturnsContextOnAPIFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		Labels: []string{"ready"},
+	})
+
+	_, err := client.SearchIssues(ctx)
+	if err == nil {
+		t.Fatal("SearchIssues() error = nil, want non-nil")
+	}
+
+	if !strings.Contains(err.Error(), "github issue search failed") {
+		t.Fatalf("SearchIssues() error = %q, want to contain %q", err.Error(), "github issue search failed")
+	}
+}
+
+func TestGitHubIssueClientMarkIssueDoneReturnsContextOnAPIFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"unprocessable"}`))
+	}))
+	defer server.Close()
+
+	client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+		DoneLabel: "done",
+	})
+
+	err := client.MarkIssueDone(ctx, "GH-42")
+	if err == nil {
+		t.Fatal("MarkIssueDone() error = nil, want non-nil")
+	}
+
+	if !strings.Contains(err.Error(), "github done label update failed") {
+		t.Fatalf("MarkIssueDone() error = %q, want to contain %q", err.Error(), "github done label update failed")
+	}
+}
+
+func TestGitHubIssueClientSearchIssuesPaginationBoundaries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		page1Count       int
+		page2Count       int
+		wantRequests     int
+		wantIssueCount   int
+		wantFirstIssueID string
+		wantLastIssueID  string
+	}{
+		{
+			name:             "exactly one full page requires follow-up request",
+			page1Count:       50,
+			page2Count:       0,
+			wantRequests:     2,
+			wantIssueCount:   50,
+			wantFirstIssueID: "GH-1",
+			wantLastIssueID:  "GH-50",
+		},
+		{
+			name:           "empty first page stops immediately",
+			page1Count:     0,
+			page2Count:     0,
+			wantRequests:   1,
+			wantIssueCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requests := 0
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				if r.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", r.Method)
+				}
+
+				if r.URL.Path != "/repos/acme/repo/issues" {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, "/repos/acme/repo/issues")
+				}
+
+				if got := r.URL.Query().Get("per_page"); got != "50" {
+					t.Fatalf("per_page query = %q, want %q", got, "50")
+				}
+
+				requests++
+				w.Header().Set("Content-Type", "application/json")
+
+				switch r.URL.Query().Get("page") {
+				case "1":
+					rows := make([]string, 0, tc.page1Count)
+					for i := 1; i <= tc.page1Count; i++ {
+						rows = append(rows, fmt.Sprintf(`{"id": %d, "number": %d, "state": "open", "title": "Issue %d", "body": "body", "labels": [{"name": "ready"}]}`,
+							i,
+							i,
+							i,
+						))
+					}
+
+					_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+				case "2":
+					rows := make([]string, 0, tc.page2Count)
+					for i := 1; i <= tc.page2Count; i++ {
+						number := tc.page1Count + i
+						rows = append(rows, fmt.Sprintf(`{"id": %d, "number": %d, "state": "open", "title": "Issue %d", "body": "body", "labels": [{"name": "ready"}]}`,
+							number,
+							number,
+							number,
+						))
+					}
+
+					_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+				default:
+					t.Fatalf("unexpected page query = %q", r.URL.Query().Get("page"))
+				}
+			}))
+			defer server.Close()
+
+			client := agentinternal.NewGitHubIssueClient(server.Client(), server.URL, "token", "acme", "repo", &agentinternal.GitHubWorkConfig{
+				Labels: []string{"ready"},
+			})
+
+			issues, err := client.SearchIssues(ctx)
+			if err != nil {
+				t.Fatalf("SearchIssues() error = %v", err)
+			}
+
+			if requests != tc.wantRequests {
+				t.Fatalf("request count = %d, want %d", requests, tc.wantRequests)
+			}
+
+			if len(issues) != tc.wantIssueCount {
+				t.Fatalf("len(issues) = %d, want %d", len(issues), tc.wantIssueCount)
+			}
+
+			if tc.wantIssueCount == 0 {
+				return
+			}
+
+			if issues[0].Key != tc.wantFirstIssueID {
+				t.Fatalf("first issue key = %q, want %q", issues[0].Key, tc.wantFirstIssueID)
+			}
+
+			if issues[len(issues)-1].Key != tc.wantLastIssueID {
+				t.Fatalf("last issue key = %q, want %q", issues[len(issues)-1].Key, tc.wantLastIssueID)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Automated merge request for GH-1

## Description
Need to test Github integration

## OpenCode output

```text
[0m
> build · gpt-5.3-codex
[0m
[0m✱ [0mGlob "**/README*"[90m in . · 1 match[0m
[0m✱ [0mGlob "README*"[90m in . · 1 match[0m
[0m→ [0mRead README.md
[0m⚙ [0mapply_patch Success. Updated the following files:
M README.md
[0m
[0m$ [0mgo test ./...
?   	gitea.lan/cubixle/agent	[no test files]
ok  	gitea.lan/cubixle/agent/internal	(cached)
[0m
[0m$ [0mgolangci-lint run
0 issues.
[0m
Updated `README.md` to clearly state this repo is a mirror:

- Added a new **Mirror Notice** section near the top in `README.md:9`.
- Text added: “This repository is a read-only mirror of a personal Gitea instance.”

I also validated the workspace after the change:

- `go test ./...` passed
- `golangci-lint run` passed with `0 issues`

If you want, I can also add the same mirror note to any project docs you expose externally (for example, contribution guidelines or repo description text).
```